### PR TITLE
Generalized SMAC

### DIFF
--- a/cross-validation/deepnet/metadata.json
+++ b/cross-validation/deepnet/metadata.json
@@ -1,0 +1,122 @@
+{
+  "name": "Deepnet's k-fold cross-validation",
+  "description": "k-fold cross-validation for deepnets",
+  "kind": "script",
+  "source_code": "script.whizzml",
+  "inputs": [
+    {
+        "name": "dataset-id",
+        "type": "dataset-id",
+        "description": "Select the dataset for training/test the model"
+    },
+    {
+        "name": "k-folds",
+        "type": "number",
+        "default": 5,
+        "description": "Select the number of folds to split the dataset"
+    },
+    {
+        "name": "objective-id",
+        "type": "string",
+        "default": "",
+        "description": "Objective field ID"
+    },
+    {
+        "name": "batch-normalization",
+        "type": "boolean",
+        "default": false,
+        "description": "Specifies whether to normalize the outputs of a network before being passed to the activation function or not."
+    },
+    {
+        "name": "default-numeric-value",
+        "type": "string",
+        "default": "",
+        "description": "A number between 0 and 1 specifying the rate at which to drop weights during training to control overfitting"
+    },
+    {
+        "name": "dropout-rate",
+        "type": "number",
+        "default": -1,
+        "description": "A number between 0 and 1 specifying the rate at which to drop weights during training to control overfitting"
+    },
+    {
+        "name": "hidden-layers",
+        "type": "list",
+        "default": [],
+        "description": "List of maps describing the number and type of layers in the network (other than the output layer, which is determined by the type of learning problem)."
+    },
+    {
+        "name": "learn-residuals",
+        "type": "boolean",
+        "default": false,
+        "description": "Specifies whether alternate layers should learn a representation of the residuals for a given layer rather than the layer itself or not."
+    },
+    {
+        "name": "learning-rate",
+        "type": "number",
+        "default": -1,
+        "description": "A number between 0 and 1 specifying the learning rate."
+    },
+    {
+        "name": "max-iterations",
+        "type": "number",
+        "default": -1,
+        "description": "A number between 100 and 100000 for the maximum number of gradient steps to take during the optimization."
+    },
+    {
+        "name": "max-training-time",
+        "type": "number",
+        "default": -1,
+        "description": "The maximum wall clock training time, in seconds, for which to train the network."
+    },
+    {
+        "name": "missing-numerics",
+        "type": "boolean",
+        "default": false,
+        "description": "Whether to create an additional binary predictor each numeric field which denotes a missing value. If false, these predictors are not created, and rows containing missing numeric values are dropped."
+    },
+    {
+        "name": "number-of-hidden-layers",
+        "type": "number",
+        "default": -1,
+        "description": "The number of hidden layers to use in the network. If the number is greater than the length of the list of hidden_layers, the list is cycled until the desired number is reached. If the number is smaller than the length of the list of hidden_layers, the list is shortened."
+    },
+    {
+        "name": "number-of-model-candidates",
+        "type": "number",
+        "default": -1,
+        "description": "An integer specifying the number of models to try during the model search."
+    },
+    {
+        "name": "search",
+        "type": "boolean",
+        "default": false,
+        "description": "An integer specifying the number of models to try during the model search."
+    },
+    {
+        "name": "suggest-structure",
+        "type": "boolean",
+        "default": false,
+        "description": "An alternative to the search technique that is usually a more efficient way to quickly train and iterate deepnets and it can reach similar results. BigML has learned some general rules about what makes one network structure better than another for a given dataset. Given your dataset, BigML will automatically suggest a structure and a set of parameter values that are likely to perform well for your dataset. This option only builds one network."
+    },
+    {
+        "name": "tree-embedding",
+        "type": "boolean",
+        "default": false,
+        "description": "Specify whether to learn a tree-based representation of the data as engineered features along with the raw features, essentially by learning trees over slices of the input space and a small amount of the training data. The theory is that these engineered features will linearize obvious non-linear dependencies before training begins, and so make learning proceed more quickly."
+    },
+    {
+        "name": "seed",
+        "type": "string",
+        "default": "cross-validation",
+        "description": "Seed for deterministic samples"
+    }
+  ],
+  "outputs": [
+    {
+        "name": "cross-validation-output",
+        "type": "evaluation-id",
+        "description": "Average of evaluations results"
+    }
+  ]
+}

--- a/cross-validation/deepnet/readme.md
+++ b/cross-validation/deepnet/readme.md
@@ -1,0 +1,114 @@
+# Deepnet's k-fold cross-validation
+
+The objective of this script is to perform a k-fold cross validation of a
+deepnet built from a dataset. The algorithm:
+
+- Divides the dataset in k parts
+- Holds out the data in one of the parts and builds a logistic regression
+  with the rest of data
+- Evaluates the deepnet with the hold out data
+- The second and third steps are repeated with each of the k parts, so that
+  k evaluations are generated
+- Finally, the evaluation metrics are averaged to provide the cross-validation
+  metrics.
+
+The **inputs** for the script are:
+
+* `dataset-id`: (dataset-id) Dataset ID for the training data
+* `k-folds`: (integer) Number of folds to split the dataset into (optional,
+                       default=5)
+* `objective-id`: (string) ID of the objective field for the model (optional)
+
+
+* `batch-normalization`: (boolean) Whether to scale each numeric field
+                         (optional)
+* `default-numeric-value`: (string) It accepts any of the following strings
+                           to substitute missing numeric values across all
+                           the numeric fields in the dataset: "mean", "median",
+                           "minimum", "maximum", "zero".(optional)
+* `dropout-rate`: (number) A number between 0 and 1 specifying the rate at
+                   which to drop weights during training to control
+                   overfitting (optional)
+* `hidden-layers`: (list) List of maps describing the number and type of
+                   layers in the network (other than the output layer, which
+                   is determined by the type of learning problem).
+                   (optional, default=[])
+* `learn-residuals`: (list) Specifies whether alternate layers should learn a
+                     representation of the residuals for a given layer
+                     rather than the layer itself or not. (optional)
+* `learning-rate`: (list) A number between 0 and 1 specifying the learning
+                   rate (optional)
+* `max-iterations`: (number) A number between 100 and 100000 for the maximum
+                    number of gradient steps to take during the
+                    optimization. (optional)
+* `max-training-time`: (number) The maximum wall-clock training time, in
+                       seconds, for which to train the network. (optional)
+* `missing-numerics`: (boolean) Sets the deepnet missing_numerics
+                                flag (optional)
+* `number-of-hidden-layers`: (number) The number of hidden layers to use in
+                             the network. If the number is greater than the
+                             length of the list of hidden_layers, the list is
+                             cycled until the desired number is reached. If
+                             the number is smaller than the length of the list
+                             of hidden_layers, the list is shortened.
+                             (optional)
+* `number-of-model-candidates`: (number) An integer specifying the number of
+                                models to try during the model search.
+                                (optional)
+* `search`: (boolean) An integer specifying the number of models to try during
+            the model search. (optional)
+* `suggest-structure`: (boolean) An alternative to the search technique that
+                       is usually a more efficient way to quickly train and
+                       iterate deepnets and it can reach similar results.
+                       BigML has learned some general rules about what makes
+                       one network structure better than another for a given
+                       dataset. Given your dataset, BigML will automatically
+                       suggest a structure and a set of parameter values that
+                       are likely to perform well for your dataset. This option
+                       only builds one network. (optional)
+* `tree-embedding`: (boolean) An alternative to the search technique that
+                    is usually a more efficient way to quickly train and
+                    iterate deepnets and it can reach similar results.
+                    BigML has learned some general rules about what makes
+                    one network structure better than another for a given
+                    dataset. Given your dataset, BigML will automatically
+                    suggest a structure and a set of parameter values that
+                    are likely to perform well for your dataset. This option
+                    only builds one network. (optional)
+* seed: (string) Seed used in random samplings (optional)
+
+
+As you can see, most of the inputs are optional. They default to the defaults
+in the platform. The `objective-id` will also be inferred from the one in
+the dataset if it is not provided.
+
+# Using the deepnet's k-fold cross-validation script
+
+One just needs to call
+
+```
+(deepnet-cross-validation dataset-id
+                          k-folds
+                          objective-id
+                          batch_normalization
+                          default-numeric-value
+                          dropout_rate
+                          hidden_layers
+                          learn_residuals
+                          learning_rate
+                          max_iterations
+                          max_training_time
+                          missing-numerics
+                          number_of_hidden_layers
+                          number_of_model_candidates
+                          search
+                          suggest_structure
+                          tree_embedding
+                          seed)
+```
+
+using the previously described inputs.
+
+The **output** of the script will be an `evaluation ID`. This evaluation is a
+cross-validation, meaning that its metrics are averages of the k evaluations
+created in the cross-validation process.

--- a/cross-validation/deepnet/script.whizzml
+++ b/cross-validation/deepnet/script.whizzml
@@ -1,0 +1,517 @@
+;; This code will eventually be defined as a library.
+
+(define DEEPNET_OPTIONS ["batch_normalization"
+                         "default_numeric_value"
+                         "dropout_rate"
+                         "hidden_layers"
+                         "learn_residuals"
+                         "learning_rate"
+                         "max_iterations"
+                         "max_training_time"
+                         "missing_numerics"
+                         "number_of_hidden_layers"
+                         "number_of_model_candidates"
+                         "search"
+                         "suggest_structure"
+                         "tree_embedding"])
+(define EVALUATION_OPTIONS ["sample_rate"
+                            "out_of_bag"
+                            "range"
+                            "replacement"
+                            "ordering"
+                            "seed"
+                            "missing_strategy"
+                            "combiner"])
+;; cross-validation
+;;
+;; creates k-fold cross-validation for a dataset
+;; Inputs:
+;;   dataset-id: (string) Dataset ID
+;;   k-folds: (integer) Number of folds
+;;   model-options: (map) Options to use in model/ensemble
+;;   evaluation-options: (map) Options to use in evaluation creation
+;;
+;; Output: (map) Average of evaluations results
+;;
+;; Raises:
+;;  101: The dataset-id argument is not a string
+;;  102: The dataset-id is not a valid dataset ID
+;;  103: The k-folds argument is not an integer
+;;  104: The k-folds argument is not >= 2
+;;  106: The objective field ID is not in the selectable IDs list
+;;
+(define (cross-validation dataset-id
+                          k-folds
+                          objective-id
+                          model-options
+                          evaluation-options)
+  (check-resource-id dataset-id "dataset")
+  (check-integer k-folds 2 false)
+  (let (dataset (fetch dataset-id)
+        dataset-name (dataset "name" false))
+    (check-dataset-objective-id objective-id dataset)
+    (let (k-fold-datasets (create-k-folds dataset-id k-folds)
+         objective-name (get-objective-name dataset objective-id)
+         evaluations (create-k-evaluations k-fold-datasets
+                                           objective-name
+                                           dataset-name
+                                           model-options
+                                           evaluation-options))
+     (create-and-wait-evaluation {"evaluations" evaluations}))))
+
+;; check-resource-id
+;;
+;; Validates that the argument is a resource ID and its type. Raises an error
+;; if otherwise.
+;;
+;; Inputs:
+;;   resource-id: (string) Resource ID
+;;   type: (string) Type of resource
+;;
+;; Output: (string) Checked resource ID
+(define (check-resource-id resource-id type)
+  (when (not (string? resource-id))
+    (raise {"message" (str "Resource ID string expected. Found "
+                           resource-id " instead.")
+            "code" 101}))
+  (when (not (= (resource-type resource-id) type))
+    (raise {"message" (str "Failed to find a correct " type " ID.")
+            "code" 102}))
+  resource-id)
+
+
+;; check-integer
+;;
+;; Validates that the argument is an integer. Raises error if otherwise.
+;;
+;; Inputs:
+;;  value: (number) Integer to be checked
+;;  minimum: (number) Minimum value (false if not set)
+;;  maximum: (number) Maximum value (false if not set)
+;;
+;; Output: (number) Checked integer
+(define (check-integer value minimum maximum)
+  (when (not (integer? value))
+    (raise {"message" (str "Integer value expected. Found " value " instead.")
+            "code" 103}))
+  (when (and minimum (< value minimum))
+    (raise {"message" (str "Minimum accepted value is " minimum ". " value
+                           " found.")
+            "code" 104}))
+  (when (and maximum (> value maximum))
+    (raise {"message" (str "Maximum accepted value is " maximum ". " value
+                           " found.")
+            "code" 105}))
+  value)
+
+;; choosable-objective-ids
+;;
+;; List of IDs of the fields in the dataset that can be chosen as objective
+;; field.
+;;
+;; Inputs:
+;;  fields: (map) Fields structure
+;; Output: (list) list of field IDs
+(define (choosable-objective-ids fields)
+  (let (field-val (lambda (fid k) (fields [fid k] false))
+        objective-types ["categorical", "numeric"]
+        pref? (lambda (k) (field-val k "preferred"))
+        pred? (lambda (k) (member? (field-val k "optype") objective-types)))
+    (filter (lambda (x) (and (pref? x) (pred? x))) (keys fields))))
+
+
+;; check-dataset-objective-id
+;;
+;; Validates that the argument is a valid objective id in the reference
+;; dataset.
+;;
+;; Inputs:
+;;  objective-id: (string) ID of the objective field
+;;  dataset: (map) Dataset resource information
+;;
+;; Output: (string) Checked objective field ID
+(define (check-dataset-objective-id objective-id dataset)
+  (let (fields (dataset "fields" {})
+        objective-ids (choosable-objective-ids fields))
+    (when (not (member? objective-id objective-ids))
+      (raise {"message" (str "Failed to find the objective ID in the dataset"
+                             " choosable fields.")
+              "code" 106}))))
+
+;; get-objective-name
+;;
+;; Returns the name of the field used as objective field
+;;
+;; Inputs:
+;;  dataset: (map) Dataset resource info
+;;  objective-id: (string) ID of the objective field
+;;
+;; Outputs: (string) Name of the objective field
+
+(define (get-objective-name dataset objective-id)
+  (let (fields (dataset "fields" {}))
+    (fields [objective-id "name"] false)))
+
+
+;; create-k-folds
+;;
+;; creating k-fold splits from a dataset
+;;
+;; Inputs:
+;;   dataset-id: (string) Dataset ID
+;;   k-folds: (integer) Number of folds
+;;
+;; Output: (list) List of dataset IDs
+;;
+(define (create-k-folds dataset-id k-folds)
+  (let (k-fold-fn (lambda (x)
+                    (create-dataset {"origin_dataset" dataset-id
+                                     "row_offset" x
+                                     "row_step" k-folds
+                                     "new_fields" [{"name" "k_fold"
+                                                    "field" (str x)}]}))
+        dataset-ids (map k-fold-fn (range 0 k-folds)))
+    (wait* dataset-ids)))
+
+;; pair-k-folds
+;;
+;; Builds a list of pairs of hold-out and complementary datasets for all
+;; the k-fold dataset IDs.
+;;
+;; Inputs:
+;;   dataset-ids: (list) List of the k-fold dataset IDs
+;;
+;; Output: (list) List of pairs [hold-out dataset, multidataset with the rest]
+;;
+(define (pair-k-folds dataset-ids)
+  (map (lambda(x)
+         [(nth dataset-ids x)
+          (concat (take x dataset-ids)
+          (drop (+ x 1) dataset-ids))])
+       (range 0 (count dataset-ids))))
+
+
+;; select-map-keys
+;;
+;; Filters the keys in a map, keeping only the ones that appear in the list.
+;;
+;; Inputs:
+;;   map: (map) Key, value maps
+;;   keys-list: (list) List of keys to be kept in the map
+;; Output: (map) filtered map with only the keys in the keys-list
+;;
+(define (select-map-keys a-map keys-list)
+  (reduce (lambda (x y) (let (value (a-map y false))
+                          (cond value (assoc x y value) x)))
+          {}
+          keys-list))
+
+;; create-k-models
+;;
+;; Creates the models for a set of k-fold datasets
+;;
+;; Inputs:
+;;   type: (string) type of model (model or ensemble)
+;;   multidatasets: (list) List of lists of datset IDs once a k-fold is
+;;                         excluded
+;;   objective-name: (string) name of the objective field
+;;   model-options: (map) Options for the model or ensemble
+;;
+;; Output: (list) model IDs
+;;
+(define (create-k-models type multidatasets objective-name model-options)
+  (let (models (map (lambda (x)
+                      (create type
+                              (merge {"datasets" x
+                                      "objective_field" objective-name}
+                                     model-options)))
+                     multidatasets))
+    (wait* models)))
+
+;; create-k-evaluations
+;;
+;; Creates the models/ensembles and evaluations for a set of k-fold datasets
+;;
+;; Inputs:
+;;   dataset-ids: (list) List of the k-fold dataset IDs
+;;   objective-name: (string) Objective field name
+;;   dataset-name: (string) Name of the origin dataset
+;;   model-options: (map) Options used to build the models/ensembles
+;;   evaluation-options: (map) Options used to build evaluations
+;;
+;; Output: (list) List of evaluation IDs
+;;
+(define (create-k-evaluations dataset-ids
+                              objective-name
+                              dataset-name
+                              model-options
+                              evaluation-options)
+  (let (number-of-models (model-options "number_of_models" 1)
+        k-fold-pairs (pair-k-folds dataset-ids)
+        deepnet-options (select-map-keys model-options DEEPNET_OPTIONS)
+        evaluation-options (select-map-keys evaluation-options
+                                            EVALUATION_OPTIONS)
+        multidatasets (map last k-fold-pairs)
+        models  (create-k-models "deepnet"
+                                  multidatasets
+                                  objective-name
+                                  deepnet-options)
+        evaluations (iterate (es []
+                              id dataset-ids
+                              mid models
+                              idx (range 1 (+ 1 (count dataset-ids))))
+                      (let (name (str "Evaluation tested with subset "
+                                      idx
+                                      " of " dataset-name)
+                            opts (assoc evaluation-options "name" name))
+                       (append es (create-evaluation id mid opts)))))
+    (wait* evaluations)))
+
+
+;; Script
+
+;;get_deepnet_options
+;;
+;; maps the options to be used in deepnets
+;; Inputs:
+;;   batch_normalization: (boolean) Whether to scale each numeric field
+;;                        (optional)
+;;   default-numeric-value: (string) It accepts any of the following strings
+;;                          to substitute missing numeric values across all
+;;                          the numeric fields in the dataset: "mean", "median",
+;;                          "minimum", "maximum", "zero".(optional)
+;;   dropout-rate: (number) A number between 0 and 1 specifying the rate at
+;;                 which to drop weights during training to control
+;;                 overfitting (optional)
+;;   hidden-layers: (list) List of maps describing the number and type of
+;;                  layers in the network (other than the output layer, which
+;;                  is determined by the type of learning problem).
+;;                  (optional, default=[])
+;;   learn-residuals: (list) Specifies whether alternate layers should learn a
+;;                    representation of the residuals for a given layer
+;;                    rather than the layer itself or not. (optional)
+;;   learning-rate: (list) A number between 0 and 1 specifying the learning
+;;                  rate (optional)
+;;   max-iterations: (number) A number between 100 and 100000 for the maximum
+;;                   number of gradient steps to take during the
+;;                   optimization. (optional)
+;;   max-training-time: (number) The maximum wall-clock training time, in
+;;                      seconds, for which to train the network. (optional)
+;;   missing-numerics: (boolean) Sets the deepnet missing_numerics
+;;                     flag (optional)
+;;   number-of-hidden-layers: (number) The number of hidden layers to use in
+;;                            the network. If the number is greater than the
+;;                            length of the list of hidden_layers, the list is
+;;                            cycled until the desired number is reached. If
+;;                            the number is smaller than the length of the list
+;;                            of hidden_layers, the list is shortened.
+;;                            (optional)
+;;   number-of-model-candidates: (number) An integer specifying the number of
+;;                               models to try during the model search.
+;;                               (optional)
+;;   search: (boolean) An integer specifying the number of models to try during
+;;           the model search. (optional)
+;;   suggest-structure: (boolean) An alternative to the search technique that
+;;                      is usually a more efficient way to quickly train and
+;;                      iterate deepnets and it can reach similar results.
+;;                      BigML has learned some general rules about what makes
+;;                      one network structure better than another for a given
+;;                      dataset. Given your dataset, BigML will automatically
+;;                      suggest a structure and a set of parameter values that
+;;                      are likely to perform well for your dataset. This option
+;;                      only builds one network. (optional)
+;;   tree-embedding: (boolean) An alternative to the search technique that
+;;                   is usually a more efficient way to quickly train and
+;;                   iterate deepnets and it can reach similar results.
+;;                   BigML has learned some general rules about what makes
+;;                   one network structure better than another for a given
+;;                   dataset. Given your dataset, BigML will automatically
+;;                   suggest a structure and a set of parameter values that
+;;                   are likely to perform well for your dataset. This option
+;;                   only builds one network. (optional)
+;;   seed: (string) Seed used in random samplings (optional)
+;;
+;; Output: (map) options map
+;;
+(define (get_deepnet_options batch_normalization
+                             default-numeric-value
+                             dropout-rate
+                             hidden-layers
+                             learn-residuals
+                             learning-rate
+                             max-iterations
+                             max-training_time
+                             missing-numerics
+                             number-of-hidden-layers
+                             number-of-model-candidates
+                             search
+                             suggest-structure
+                             tree-embedding
+                             seed)
+  (let (options {"tree_embedding" tree-embedding
+                 "suggest_structure" suggest-structure
+                 "search" search
+                 "missing_numerics" missing-numerics
+                 "learn_residuals" learn-residuals}
+        options (if (empty? seed)
+                    options
+                    (assoc options "seed" seed))
+        options (if (positive? number-of-model-candidates)
+                    (assoc options "number_of_model_candidates"
+                                   number-of-model-candidates)
+                    options)
+        options (if (positive? number-of-hidden-layers)
+                    (assoc options "number_of_hidden_layers"
+                                   number-of-hidden-layers)
+                    options)
+        options (if (positive? max-training-time)
+                    (assoc options "max_training_time"
+                                   max-training-time)
+                    options)
+        options (if (positive? max-iterations)
+                    (assoc options "max_iterations"
+                                   max-iterations)
+                    options)
+        options (if (positive? learning-rate)
+                    (assoc options "learning_rate"
+                                   learning-rate)
+                    options)
+        options (if (empty? hidden-layers)
+                     options
+                     (assoc options "hidden_layers"
+                                    hidden-layers))
+        options (if (positive? dropout-rate)
+                    (assoc options "dropout_rate"
+                                   dropout-rate)
+                     options))
+    (if (empty? default-numeric-value)
+        options
+        (assoc options "default_numeric_value"
+                       default-numeric-value))))
+
+
+;; deepnet-cross-validation
+;;
+;; creates k-fold cross-validation for a dataset using deepnets
+;; Inputs:
+;;   dataset-id: (string) Dataset ID
+;;   k-folds: (integer) Number of folds
+;;   objective-id: (string) ID of the objective field
+;;   batch_normalization: (boolean) Whether to scale each numeric field
+;;                        (optional)
+;;   default-numeric-value: (string) It accepts any of the following strings
+;;                          to substitute missing numeric values across all
+;;                          the numeric fields in the dataset: "mean", "median",
+;;                          "minimum", "maximum", "zero".(optional)
+;;   dropout-rate: (number) A number between 0 and 1 specifying the rate at
+;;                 which to drop weights during training to control
+;;                 overfitting (optional)
+;;   hidden-layers: (list) List of maps describing the number and type of
+;;                  layers in the network (other than the output layer, which
+;;                  is determined by the type of learning problem).
+;;                  (optional, default=[])
+;;   learn-residuals: (list) Specifies whether alternate layers should learn a
+;;                    representation of the residuals for a given layer
+;;                    rather than the layer itself or not. (optional)
+;;   learning-rate: (list) A number between 0 and 1 specifying the learning
+;;                  rate (optional)
+;;   max-iterations: (number) A number between 100 and 100000 for the maximum
+;;                   number of gradient steps to take during the
+;;                   optimization. (optional)
+;;   max-training-time: (number) The maximum wall-clock training time, in
+;;                      seconds, for which to train the network. (optional)
+;;   missing-numerics: (boolean) Sets the deepnet missing_numerics
+;;                     flag (optional)
+;;   number-of-hidden-layers: (number) The number of hidden layers to use in
+;;                            the network. If the number is greater than the
+;;                            length of the list of hidden_layers, the list is
+;;                            cycled until the desired number is reached. If
+;;                            the number is smaller than the length of the list
+;;                            of hidden_layers, the list is shortened.
+;;                            (optional)
+;;   number-of-model-candidates: (number) An integer specifying the number of
+;;                               models to try during the model search.
+;;                               (optional)
+;;   search: (boolean) An integer specifying the number of models to try during
+;;           the model search. (optional)
+;;   suggest-structure: (boolean) An alternative to the search technique that
+;;                      is usually a more efficient way to quickly train and
+;;                      iterate deepnets and it can reach similar results.
+;;                      BigML has learned some general rules about what makes
+;;                      one network structure better than another for a given
+;;                      dataset. Given your dataset, BigML will automatically
+;;                      suggest a structure and a set of parameter values that
+;;                      are likely to perform well for your dataset. This option
+;;                      only builds one network. (optional)
+;;   tree-embedding: (boolean) An alternative to the search technique that
+;;                   is usually a more efficient way to quickly train and
+;;                   iterate deepnets and it can reach similar results.
+;;                   BigML has learned some general rules about what makes
+;;                   one network structure better than another for a given
+;;                   dataset. Given your dataset, BigML will automatically
+;;                   suggest a structure and a set of parameter values that
+;;                   are likely to perform well for your dataset. This option
+;;                   only builds one network. (optional)
+;;   seed: (string) Seed used in random samplings (optional)
+;;
+;; Output: (map) Average of evaluations results
+;;
+(define (deepnet-cross-validation dataset-id
+                                  k-folds
+                                  objective-id
+                                  batch-normalization
+                                  default-numeric-value
+                                  dropout-rate
+                                  hidden-layers
+                                  learn-residuals
+                                  learning-rate
+                                  max-iterations
+                                  max-training-time
+                                  missing-numerics
+                                  number-of-hidden-layers
+                                  number-of-model-candidates
+                                  search
+                                  suggest-structure
+                                  tree-embedding
+                                  seed)
+  (let (options (get_deepnet_options batch-normalization
+                                     default-numeric-value
+                                     dropout-rate
+                                     hidden-layers
+                                     learn-residuals
+                                     learning-rate
+                                     max-iterations
+                                     max-training-time
+                                     missing-numerics
+                                     number-of-hidden-layers
+                                     number-of-model-candidates
+                                     search
+                                     suggest-structure
+                                     tree-embedding
+                                     seed)
+        xxx (log-info "***" options)
+        objective-id (if (empty? objective-id)
+                         (dataset-get-objective-id dataset-id)
+                         objective-id))
+    (cross-validation dataset-id k-folds objective-id options {})))
+
+
+(define cross-validation-output
+  (deepnet-cross-validation dataset-id
+                            k-folds
+                            objective-id
+                            batch-normalization
+                            default-numeric-value
+                            dropout-rate
+                            hidden-layers
+                            learn-residuals
+                            learning-rate
+                            max-iterations
+                            max-training-time
+                            missing-numerics
+                            number-of-hidden-layers
+                            number-of-model-candidates
+                            search
+                            suggest-structure
+                            tree-embedding
+                            seed))

--- a/cross-validation/metadata.json
+++ b/cross-validation/metadata.json
@@ -2,5 +2,5 @@
   "name": "Cross validation",
   "description": "A collection of whizzml scripts performing k-fold cross-validation",
   "kind": "package",
-  "components": ["basic", "model", "ensemble", "logistic-regression", "boosted-ensemble"]
+  "components": ["basic", "model", "ensemble", "logistic-regression", "boosted-ensemble", "deepnet"]
 }

--- a/cross-validation/test/test.sh
+++ b/cross-validation/test/test.sh
@@ -47,7 +47,7 @@ declare regex="\"outputs\": \[\[\"cross-validation-output\",\
 declare file_content=$( cat "${file}" )
 if [[ " $file_content " =~ $regex ]]
     then
-        log "model OK"
+        echo "model OK"
     else
         echo "model KO:\n $file_content"
         exit 1
@@ -64,7 +64,7 @@ declare regex="\"outputs\": \[\[\"cross-validation-output\",\
 declare file_content=$( cat "${file}" )
 if [[ " $file_content " =~ $regex ]]
     then
-        log "ensemble OK"
+        echo "ensemble OK"
     else
         echo "ensemble KO:\n $file_content"
         exit 1
@@ -80,7 +80,7 @@ declare regex="\"outputs\": \[\[\"cross-validation-output\",\
 declare file_content=$( cat "${file}" )
 if [[ " $file_content " =~ $regex ]]
     then
-        log "logistic regression OK"
+        echo "logistic regression OK"
     else
         echo "logistic regression KO:\n $file_content"
         exit 1
@@ -97,9 +97,25 @@ declare regex="\"outputs\": \[\[\"cross-validation-output\",\
 declare file_content=$( cat "${file}" )
 if [[ " $file_content " =~ $regex ]]
     then
-        log "boosted ensemble OK"
+        echo "boosted ensemble OK"
     else
         echo "boosted ensemble KO:\n $file_content"
+        exit 1
+fi
+log "Testing deepnet script --------------------"
+# running the execution with the given inputs
+run_bigmler execute --scripts .build/deepnet/scripts \
+                    --inputs test_inputs.json  --output-dir cmd/results
+# check the outputs
+declare file="cmd/results/whizzml_results.json"
+declare regex="\"outputs\": \[\[\"cross-validation-output\",\
+ \"evaluation/[a-f0-9]{24}\", \"evaluation\"\]\]"
+declare file_content=$( cat "${file}" )
+if [[ " $file_content " =~ $regex ]]
+    then
+        echo "deepnet OK"
+    else
+        echo "deepnet KO:\n $file_content"
         exit 1
 fi
 

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -12,11 +12,13 @@
     {
       "name": "validation-id",
       "type": "dataset-id",
+      "default": "",
       "description": "Held out data to use for model selection.  If not specified, a randomly selected subset of the training instances are used for the validation set."
     },
     {
       "name": "test-id",
       "type": "dataset-id",
+      "default": "",
       "description": "A dataset on which to evaluate the final selected model, for the purposes of performance estimation.  If not specified, the validation set is used."
     },
     {

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -5,9 +5,21 @@
   "source_code": "script.whizzml",
   "inputs":[
     {
-      "name": "dataset-id",
+      "name": "train-id",
       "type": "dataset-id",
-      "description": "Dataset for which we are seeking an optimal model"
+      "description": "Training dataset for which we are seeking an optimal model"
+    },
+    {
+      "name": "validation-id",
+      "type": "dataset-id",
+      "default": null,
+      "description": "Held out data to use for model selection.  If not specified, a randomly selected subset of the training instances are used for the validation set."
+    },
+    {
+      "name": "test-id",
+      "type": "dataset-id",
+      "description": "A dataset on which to evaluate the final selected model, for the purposes of performance estimation.  If not specified, the validation set is used."
+      "default": null,
     },
     {
       "name": "objective-id",

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -1,19 +1,19 @@
 {
-  "name": "Ensemble optimization",
-  "description": "Script for ensemble optimization using SMACdown.  The script can be used for both classification and regression ensembles, provided you select the appropriate metric to be optimized (see below).\n\nClassification metrics:\n\n- average_recall\n\n- average_phi\n\n- accuracy\n\n- average_precision\n\n- average\\_f\\_measure\n\nRegression metrics:\n\n- r_squared.",
+  "name": "Model optimization",
+  "description": "Script for optimization using SMACdown.  The script can be used for both classification and regression ensembles, provided you select the appropriate metric to be optimized (see below).\n\nClassification metrics:\n\n- average_recall\n\n- average_phi\n\n- accuracy\n\n- average_precision\n\n- average\\_f\\_measure\n\nRegression metrics:\n\n- r_squared.",
   "kind": "script",
   "source_code": "script.whizzml",
   "inputs":[
     {
       "name": "dataset-id",
       "type": "dataset-id",
-      "description": "Dataset for which we are seeking an optimal ensemble"
+      "description": "Dataset for which we are seeking an optimal model"
     },
     {
       "name": "objective-id",
       "type": "string",
       "default": "default",
-      "description": "The ensemble's objective field, or 'default' to use the dataset's default"
+      "description": "The objective field, or 'default' to use the dataset's default"
     },
     {
       "name": "metric",

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -18,8 +18,8 @@
     {
       "name": "test-id",
       "type": "dataset-id",
-      "description": "A dataset on which to evaluate the final selected model, for the purposes of performance estimation.  If not specified, the validation set is used."
       "default": null,
+      "description": "A dataset on which to evaluate the final selected model, for the purposes of performance estimation.  If not specified, the validation set is used."
     },
     {
       "name": "objective-id",

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -40,6 +40,12 @@
       "description": "Whether to try individual trees in the search"
     },
     {
+      "name": "test-ensemble",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to try decision forests in the search"
+    },
+    {
       "name": "test-boosting",
       "type": "boolean",
       "default": false,

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -34,6 +34,24 @@
       "description": "Metric to optimize.  Can be average_recall, average_phi, accuracy, average_precision, average_f_measure for classification or r_squared for regression."
     },
     {
+      "name": "test-model",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to try individual trees in the search"
+    },
+    {
+      "name": "test-boosting",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to try boosted ensembles in the search"
+    },
+    {
+      "name": "test-logistic",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to try logistic regression in the search"
+    },
+    {
       "name": "delete-resources",
       "type": "boolean",
       "default": true,

--- a/smacdown-ensemble/metadata.json
+++ b/smacdown-ensemble/metadata.json
@@ -12,13 +12,11 @@
     {
       "name": "validation-id",
       "type": "dataset-id",
-      "default": null,
       "description": "Held out data to use for model selection.  If not specified, a randomly selected subset of the training instances are used for the validation set."
     },
     {
       "name": "test-id",
       "type": "dataset-id",
-      "default": null,
       "description": "A dataset on which to evaluate the final selected model, for the purposes of performance estimation.  If not specified, the validation set is used."
     },
     {

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -39,7 +39,7 @@
 (define (uniformize-params params)
   (iterate (p params ap ALL_ATTRS)
     (if (not (contains? p ap))
-        (assoc p ap false)
+        (assoc p ap "N/A")
         p)))
 
 ;; Here's a custom generator for creating BigML models.
@@ -143,6 +143,13 @@
           p
           (dissoc p aa)))))
 
+(define (train-general params)
+  (let (type (params "resource_type")
+        res-params (strict-params params))
+    (if (= type "bensemble")
+      (create "ensemble" res-params)
+      (create "type" res-params))))
+
 ;; This function takes a training and test set (and an objective field
 ;; id) and evaluates a set of parameters by training a logistic regression with
 ;; those parameters and performing an evaluation on them.  We decide
@@ -159,18 +166,7 @@
           mod-fn (lambda (p) (merge p train-params))
           eval-fn (lambda (m) {"model" m "dataset" test})
           mod-params (map mod-fn params)
-          logistic? (lambda(p) (= (p "resource_type" "") "logisticregression"))
-          model? (lambda(p) (= (p "resource_type" "") "model"))
-          ensemble? (lambda(p) (= (p "resource_type" "") "ensemble"))
-          bensemble? (lambda(p) (= (p "resource_type" "") "bensemble"))
-          logistic-params (map strict-params (filter logistic? mod-params))
-          model-params (map strict-params (filter model? mod-params))
-          ensemble-params (map strict-params (filter ensemble? mod-params))
-          bensemble-params (map strict-params (filter bensemble? mod-params))
-          mod-ids (create* "logisticregression" logistic-params)
-          mod-ids (concat mod-ids (create* "model" model-params))
-          mod-ids (concat mod-ids (create* "ensemble" ensemble-params))
-          mod-ids (concat mod-ids (create* "ensemble" bensemble-params))
+          mod-ids (map train-general mod-params)
           eval-ids (create* "evaluation" (map eval-fn mod-ids))
           phi (lambda (ev)
                 (let (metric-value (ev ["result" "model" metric] false))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -1,26 +1,155 @@
+(define ALL_ATTRS ["resource_type" "stat_pruning" "balance_objective"
+                   "randomize" "node_threshold" "random_candidate_ratio"
+                   "number_of_models" "bias" "c" "eps" "default_numeric_value"
+                   "missing_numerics" "normalize" "regularization"
+                   "boosting"])
+
+(define ATTRS_PER_TYPE {"model" ["stat_pruning" "balance_objective"
+                                 "randomize" "node_threshold"]
+                        "ensemble" ["random_candidate_ratio" "stat_pruning"
+                                    "balance_objective" "number_of_models"
+                                    "randomize" "node_threshold"]
+                        "bensemble" ["stat_pruning" "balance_objective"
+                                     "boosting" "randomize" "node_threshold"]
+                        "logisticregression" ["bias" "c" "eps"
+                                              "default_numeric_value"
+                                              "missing_numerics"
+                                              "normalize" "regularization"]})
+
+;; Here's a custom generator for creating BigML models, ensembles, boosted
+;; ensembles or logistic regressions
+(define (smacdown-params-generator objective-type)
+  (lambda ()
+    (let (regression (= "numeric" objective-type)
+          type (rand)
+          type (if (and regression (< type 0.25))
+                   (* 4 type)
+                   type)
+          params (cond (< type 0.25)
+                       (smacdown-logistic-regression-params-generator)
+                       (< type 0.5)
+                       (smacdown-model-params-generator objective-type)
+                       (< type 0.75)
+                       (smacdown-ensemble-params-generator objective-type)
+                       (smacdown-boosted-ensemble-params-generator
+                        objective-type)))
+      (uniformize-params params))))
+
+;; The smacdown primitive needs a homogeneous set of attributes
+(define (uniformize-params params)
+  (iterate (p params ap ALL_ATTRS)
+    (if (not (contains? p ap))
+        (assoc p ap false)
+        p)))
+
+;; Here's a custom generator for creating BigML models.
+(define (smacdown-model-params-generator objective-type)
+  (let (max-trees 127
+        max-nodes 1999
+        regression (= "numeric" objective-type)
+        cand {"resource_type" "model"
+              "stat_pruning" (if (< (rand) 0.5) false true)
+              "balance_objective" (if (or regression (< (rand) 0.5))
+                                      false
+                                      true)
+              "randomize" true
+              "node_threshold" (round (rand-range 4 max-nodes))})
+    cand))
+
 ;; Here's a custom generator for creating BigML ensembles.  As
 ;; "random_candidate_ratio" tends towards 1, the ensemble becomes a
 ;; bag.
-(define (smacdown-ensemble--model-params-generator objective-type)
-  (lambda ()
-    (let (max-trees 127
-          max-nodes 1999
-          regression (= "numeric" objective-type)
-          cand {"random_candidate_ratio" (rand)
-                "stat_pruning" (if (< (rand) 0.5) false true)
-                "balance_objective" (if (or regression (< (rand) 0.5)) false true)
-                "number_of_models" (+ 1 (round (exp (* (log max-trees) (rand)))))
-                "randomize" true
-                "node_threshold" (round (rand-range 4 max-nodes))})
-      cand)))
+(define (smacdown-ensemble-params-generator objective-type)
+  (let (max-trees 127
+        max-nodes 1999
+        regression (= "numeric" objective-type)
+        cand {"resource_type" "ensemble"
+              "random_candidate_ratio" (rand)
+              "stat_pruning" (if (< (rand) 0.5) false true)
+              "balance_objective" (if (or regression (< (rand) 0.5)) false true)
+              "number_of_models" (+ 1 (round (exp (* (log max-trees) (rand)))))
+              "randomize" true
+              "node_threshold" (round (rand-range 4 max-nodes))})
+    cand))
+
+;; Here's a custom generator for creating BigML logistic regressions.
+(define (smacdown-logistic-regression-params-generator)
+  (let (max-c 256
+        dnv-random (rand)
+        default-numeric-value (cond (> dnv-random 0.8)
+                                    "mean"
+                                    (> dnv-random 0.6)
+                                    "median"
+                                    (> dnv-random 0.4)
+                                    "minimum"
+                                    (> dnv-random 0.2)
+                                    "maximum"
+                                    "zero")
+        c (* max-c (rand))
+        missing-numerics (if (< (rand) 0.5) false true)
+        normalize (if (< (rand) 0.5) false true)
+        regularization (if (< (rand) 0.5) "l1" "l2")
+        bias (if (< (rand) 0.5) false true)
+        eps (* (rand) 0.5)
+        cand {"resource_type" "logisticregression"
+              "bias" bias
+              "c" c
+              "eps" eps
+              "default_numeric_value" default-numeric-value
+              "missing_numerics" missing-numerics
+              "normalize" normalize
+              "regularization" regularization})
+    cand))
+
+;; Here's a custom generator for creating BigML boosted ensembles.
+(define (smacdown-boosted-ensemble-params-generator objective-type)
+  (let (max-trees 127
+        max-nodes 1999
+        max-iterations 256
+        regression (= "numeric" objective-type)
+        iterations (round (* max-iterations (rand)))
+        early-holdout (rand)
+        early-out-of-bag (if (< (rand) 0.5) false true)
+        step-out-of-bag (if (< (rand) 0.5) false true)
+        learning-rate (rand)
+        learning-rate (if (= learning-rate 1)
+                          (- learning-rate 0.00001)
+                          learning-rate)
+        learning-rate (if (= learning-rate 0)
+                          (+ learning-rate 0.00001)
+                          learning-rate)
+        cand {"resource_type" "bensemble"
+              "stat_pruning" (if (< (rand) 0.5) false true)
+              "balance_objective" (if (or regression (< (rand) 0.5))
+                                      false
+                                      true)
+              "boosting" {"iterations" iterations
+                          "early_holdout" early-holdout
+                          "early_out_of_bag" early-out-of-bag
+                          "learning_rate" learning-rate
+                          "step_out_of_bag" step-out-of-bag}
+              "randomize" true
+              "node_threshold" (round (rand-range 4 max-nodes))})
+    cand))
+
+
+;; Filter the uniformized attributs to use the applicable to each resource type
+(define (strict-params params)
+  (let (type (params "resource_type")
+        params (dissoc params "resource_type")
+        attrs (ATTRS_PER_TYPE type []))
+    (iterate (p params aa ALL_ATTRS)
+      (if (member? aa attrs)
+          p
+          (dissoc p aa)))))
 
 ;; This function takes a training and test set (and an objective field
-;; id) and evaluates a set of parameters by training a model with
+;; id) and evaluates a set of parameters by training a logistic regression with
 ;; those parameters and performing an evaluation on them.  We decide
-;; that phi is the metric we'd like to opimize, so we pull 1 - phi out
+;; that phi is the metric we'd like to optimize, so we pull 1 - phi out
 ;; of each evaluation to return as the objective, as the algorithm
 ;; seeks to *minimize* a value and we want to *maximize* phi.
-(define (smacdown-ensemble--evaluator train test obj metric name)
+(define (smacdown-evaluator train test obj metric name)
   (lambda (params itr)
     (log-info "Evaluating " (count params) " candidates...")
     (let (train-params {"dataset" train
@@ -29,7 +158,19 @@
                         "name" (str name " smacdown itr " itr " test model")}
           mod-fn (lambda (p) (merge p train-params))
           eval-fn (lambda (m) {"model" m "dataset" test})
-          mod-ids (create* "ensemble" (map mod-fn params))
+          mod-params (map mod-fn params)
+          logistic? (lambda(p) (= (p "resource_type" "") "logisticregression"))
+          model? (lambda(p) (= (p "resource_type" "") "model"))
+          ensemble? (lambda(p) (= (p "resource_type" "") "ensemble"))
+          bensemble? (lambda(p) (= (p "resource_type" "") "bensemble"))
+          logistic-params (map strict-params (filter logistic? mod-params))
+          model-params (map strict-params (filter model? mod-params))
+          ensemble-params (map strict-params (filter ensemble? mod-params))
+          bensemble-params (map strict-params (filter bensemble? mod-params))
+          mod-ids (create* "logisticregression" logistic-params)
+          mod-ids (concat mod-ids (create* "model" model-params))
+          mod-ids (concat mod-ids (create* "ensemble" ensemble-params))
+          mod-ids (concat mod-ids (create* "ensemble" bensemble-params))
           eval-ids (create* "evaluation" (map eval-fn mod-ids))
           phi (lambda (ev)
                 (let (metric-value (ev ["result" "model" metric] false))
@@ -46,13 +187,13 @@
         train-id (create-dataset train-params)
         test-id (create-dataset test-params)
         _ (wait* [train-id test-id])
-        eval-fn (smacdown-ensemble--evaluator train-id
-                                              test-id
-                                              objective-id
-                                              metric
-                                              "smacdown-ensemble")
-        generator (smacdown-ensemble--model-params-generator objective-type)
-        output (smacdown-optimize generator eval-fn "smacdown-ensemble"))
+        eval-fn (smacdown-evaluator train-id
+                                    test-id
+                                    objective-id
+                                    metric
+                                    "smacdown-model")
+        generator (smacdown-params-generator objective-type)
+        output (smacdown-optimize generator eval-fn "smacdown-model"))
      (for (p output)
        (assoc (dissoc p smacdown--actual)
           metric (- 1 (p smacdown--actual))))))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -201,9 +201,8 @@
             type (params "resource_type")
             mkey (str metric)
             res-params (dissoc (params-for-resource params) "resource_type"))
-        {"parameters" res-params
-         "resource_type" type
-         mkey (- 1 (p smacdown--actual))}))))
+        (assoc {"parameters" res-params "resource_type" type}
+               mkey (- 1 (p smacdown--actual)))))))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -39,6 +39,7 @@
                        (< type 0.5)
                        ;; (smacdown-model-params-generator objective-type)
                        (smacdown-boosted-ensemble-params-generator
+                        objective-type)
                        (< type 0.75)
                        (smacdown-ensemble-params-generator objective-type)
                        (smacdown-boosted-ensemble-params-generator
@@ -178,9 +179,9 @@
                                     "smacdown-model")
         generator (smacdown-params-generator objective-type)
         output (smacdown-optimize generator eval-fn "smacdown-model"))
-     (for (p output)
-       (assoc (dissoc p smacdown--actual)
-          metric (- 1 (p smacdown--actual))))))
+    (for (p output)
+      (assoc (dissoc p smacdown--actual)
+             metric (- 1 (p smacdown--actual))))))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -255,6 +255,7 @@
         otype (or ((fetch train-id) ["fields" obj-id "optype"] false)
                   (raise {"message" (str "Invalid objective field")}))
         mtypes (make-model-types otype test-boosting test-model test-logistic)
+        _ (log-info "Search over types: " (str mtypes))
         params (find-optimal-parameters trid tid obj-id otype mtypes)
         _ (log-info "SMACdown search complete")
         _ (when delete-resources

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -155,7 +155,7 @@
                        (ev ["result" "model" metric] false)
                        (let ([class class-met] (tail met-matches)
                              pcs (ev ["result" "model" "per_class_statistics"])
-                             cstats (stats-for-class pcs))
+                             cstats (stats-for-class class pcs))
                          (cstats class-met))))
     (if (not (number? metric-value))
       (raise {"message" (str metric " is not a valid metric!")

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -134,7 +134,7 @@
     (iterate (p params aa ALL_ATTRS)
       (if (member? aa attrs) p (dissoc p aa)))))
 
-(define (train-general params)
+(define (train-general params dataset-id)
   (let (type (params "resource_type")
         res-params (strict-params params))
     (if (= type "bensemble")
@@ -219,11 +219,13 @@
             (map safe-delete (created-resources)))
         _ (log-info "Training model on full dataset...")
         mod-prms (merge ((head params) "parameters" {})
-                        {"objective_field" obj-id "seed" "SMACdown"})
-        full-mod (create-ensemble dataset-id mod-prms)
+                        {"objective_field" obj-id
+                         "name" "SMACdown Final Model"
+                         "seed" "SMACdown"})
+        full-mod (train-general (assoc mod-prms "dataset" dataset-id))
         train-id (create-dataset train-params)
         test-id (create-dataset test-params)
-        best-mod (create-ensemble train-id mod-prms)
+        best-mod (train-general (assoc mod-prms "dataset" train-id))
         best-eval (create-evaluation best-mod test-id))
     (wait* [best-eval full-mod])
     (when delete-resources

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -189,7 +189,7 @@
                                     objective-id
                                     metric
                                     "smacdown-model")
-        generator (smacdown-params-generator model-types objective-type)
+        generator (params-generator model-types objective-type)
         output (smacdown-optimize generator eval-fn "smacdown-model"))
     (for (p output)
       (assoc (dissoc p smacdown--actual)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -199,10 +199,11 @@
     (for (p output)
       (let (params (p "parameters")
             type (params "resource_type")
+            mkey (str metric)
             res-params (dissoc (params-for-resource params) "resource_type"))
         {"parameters" res-params
          "resource_type" type
-         metric (- 1 (p smacdown--actual))}))))
+         mkey (- 1 (p smacdown--actual))}))))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -10,8 +10,8 @@
                         "ensemble" ["random_candidate_ratio" "stat_pruning"
                                     "balance_objective" "number_of_models"
                                     "randomize" "node_threshold"]
-                        "bensemble" ["stat_pruning" "balance_objective"
-                                     "randomize" "node_threshold"]
+                        "boosted-ensemble" ["stat_pruning" "balance_objective"
+                                            "randomize" "node_threshold"]
                         "logisticregression" ["bias" "c" "eps"
                                               "default_numeric_value"
                                               "missing_numerics"
@@ -109,7 +109,7 @@
         max-nodes 1999
         max-iterations 256
         regression (= "numeric" objective-type)
-        cand {"resource_type" "bensemble"
+        cand {"resource_type" "boosted-ensemble"
               "stat_pruning" (if (< (rand) 0.5) false true)
               "balance_objective" (if (or regression (< (rand) 0.5))
                                       false
@@ -132,13 +132,18 @@
     (iterate (p params aa ALL_ATTRS)
       (if (member? aa attrs) p (dissoc p aa)))))
 
-(define (train-general params)
+(define (params-for-resource params)
   (let (type (params "resource_type")
         res-params (strict-params params))
-    (if (= type "bensemble")
+    (if (= type "boosted-ensemble")
       (let (bparams (select-boosting-params params))
-        (create "ensemble" (assoc res-params "boosting" bparams)))
-      (create type res-params))))
+        (assoc res-params "boosting" bparams))
+      res-params)))
+
+(define (train-general params)
+  (let (type (params "resource_type")
+        res-params (dissoc (params-for-resource params) "resource_type"))
+    (create (if (= type "boosted-ensemble") "ensemble" type) res-params)))
 
 (define (stats-for-class class per-class-stats)
   (some (lambda (c) (when (= class (c "class_name")) c)) per-class-stats))
@@ -192,8 +197,12 @@
         generator (params-generator model-types objective-type)
         output (smacdown-optimize generator eval-fn "smacdown-model"))
     (for (p output)
-      (assoc (dissoc p smacdown--actual)
-             metric (- 1 (p smacdown--actual))))))
+      (let (params (p "parameters")
+            type (params "resource_type")
+            res-params (dissoc (params-for-resource params) "resource_type"))
+        {"parameters" res-params
+         "resource_type" type
+         metric (- 1 (p smacdown--actual))}))))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)
@@ -229,9 +238,13 @@
               (prog (when write (log-info "Test set is " test-id)) test-id)))
     (wait* [trid tid vid])))
 
-(define (make-model-types objective-type test-boosting test-model test-logistic)
+(define (make-model-types objective-type
+                          test-ensemble
+                          test-boosting
+                          test-model
+                          test-logistic)
   (let (regression (= "numeric" objective-type)
-        test-map {"ensemble" true
+        test-map {"ensemble" test-ensemble
                   "model" test-model
                   "boosted-ensemble" test-boosting
                   "logisticregression" (and test-logistic (not regression))})
@@ -245,6 +258,7 @@
                            test-id
                            objective-id
                            metric
+                           test-ensemble
                            test-boosting
                            test-model
                            test-logistic)
@@ -254,7 +268,11 @@
                  objective-id)
         otype (or ((fetch train-id) ["fields" obj-id "optype"] false)
                   (raise {"message" (str "Invalid objective field")}))
-        mtypes (make-model-types otype test-boosting test-model test-logistic)
+        mtypes (make-model-types otype
+                                 test-ensemble
+                                 test-boosting
+                                 test-model
+                                 test-logistic)
         _ (log-info "Search over types: " (str mtypes))
         params (find-optimal-parameters trid tid obj-id otype mtypes)
         _ (log-info "SMACdown search complete")
@@ -286,6 +304,7 @@
                      test-id
                      objective-id
                      metric
+                     test-ensemble
                      test-boosting
                      test-model
                      test-logistic))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -24,8 +24,11 @@
   (let (assoc-param (lambda (m pname) (assoc m pname (amap pname))))
     (reduce assoc-param {} BOOSTING_PARAMS)))
 
-;; Here's a custom generator for creating BigML models, ensembles, boosted
-;; ensembles or logistic regressions
+;; Here's a custom generator for creating BigML models, ensembles,
+;; boosted ensembles or logistic regressions.  For now, we've disabled
+;; models and logistic regressions due to an external issue, but if
+;; you comment in the uncommented lines and comment out as necessary
+;; in the cond statement you should be able to re-enable them.
 (define (smacdown-params-generator objective-type)
   (lambda ()
     (let (regression (= "numeric" objective-type)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -150,8 +150,8 @@
   (let (metric-value (ev ["result" "model" metric] false))
     (if (not (number? metric-value))
       (raise {"message" (str metric " is not a valid metric!")
-                            "code" -30})
-      (- 1 metric-value))))
+              "code" -30})
+      metric-value)))
 
 ;; This function takes a training and test set (and an objective field
 ;; id) and evaluates a set of parameters by training a logistic regression with
@@ -172,7 +172,7 @@
           mod-ids (map train-general mod-params)
           eval-ids (create* "evaluation" (map eval-fn mod-ids)))
       (log-info "Evaluation complete.")
-      (map (lambda (eid) (metric-from-eval metric (fetch (wait eid))))
+      (map (lambda (eid) (- 1 (metric-from-eval metric (fetch (wait eid)))))
            eval-ids))))
 
 ;; Find optimal parameters using SMACdown

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -30,13 +30,15 @@
   (lambda ()
     (let (regression (= "numeric" objective-type)
           type (rand)
-          type (if (and regression (< type 0.25))
-                   (* 4 type)
-                   type)
+          ;; type (if (and regression (< type 0.25))
+          ;;         (* 4 type)
+          ;;         type)
           params (cond (< type 0.25)
-                       (smacdown-logistic-regression-params-generator)
+                       ;; (smacdown-logistic-regression-params-generator)
+                       (smacdown-ensemble-params-generator objective-type)
                        (< type 0.5)
-                       (smacdown-model-params-generator objective-type)
+                       ;; (smacdown-model-params-generator objective-type)
+                       (smacdown-boosted-ensemble-params-generator
                        (< type 0.75)
                        (smacdown-ensemble-params-generator objective-type)
                        (smacdown-boosted-ensemble-params-generator
@@ -46,9 +48,7 @@
 ;; The smacdown primitive needs a homogeneous set of attributes
 (define (uniformize-params params)
   (iterate (p params ap ALL_ATTRS)
-    (if (not (contains? p ap))
-        (assoc p ap "N/A")
-        p)))
+    (if (not (contains? p ap)) (assoc p ap "N/A") p)))
 
 ;; Here's a custom generator for creating BigML models.
 (define (smacdown-model-params-generator objective-type)
@@ -170,12 +170,8 @@
       (map (lambda (eid) (phi (fetch (wait eid)))) eval-ids))))
 
 ;; Find optimal parameters using SMACdown
-(define (find-optimal-parameters train-params objective-id objective-type)
-  (let (test-params (assoc train-params "out_of_bag" true)
-        train-id (create-dataset train-params)
-        test-id (create-dataset test-params)
-        _ (wait* [train-id test-id])
-        eval-fn (smacdown-evaluator train-id
+(define (find-optimal-parameters train-id test-id objective-id objective-type)
+  (let (eval-fn (smacdown-evaluator train-id
                                     test-id
                                     objective-id
                                     metric
@@ -197,21 +193,44 @@
       (let (id ((fetch r) "output_dataset_resource" false))
         (when id (safe-delete id))))))
 
+(define (get-datasets train-id validation-id test-id write)
+  (let (treq {"origin_dataset" train-id
+              "sample_rate" 0.85
+              "replacement" false
+              "seed" "SMACdown"}
+        vreq (assoc train-params "out_of_bag" true)
+        [trid vid] (if (empty? validation-id)
+                     (let (tset (create-dataset treq)
+                           vset (create-dataset vreq)
+                           _ (when write
+                               (log-warn "No validation set specified")
+                               (log-info "Created validation set is " vset)))
+                       [tset vset])
+                     (prog (when write
+                             (log-info "Validation set is " validation-id))
+                           [train-id validation-id]))
+        tid (if (empty? test-id)
+              (prog (when write
+                      (log-warn "No test set specified; Using validation set"))
+                    vid)
+              (prog (when write (log-info "Test set is " test-id)) test-id)))
+    (wait* [trid tid vid])))
+
 ;; Take a dataset, create a training and test set, and find the
 ;; optimal parameters.  The function returns a list of parameters
 ;; ranked by objective.
-(define (optimize-ensemble dataset-id objective-id metric)
-  (let (train-params {"origin_dataset" dataset-id
-                      "sample_rate" 0.8
-                      "replacement" false
-                      "seed" "SMACdown"}
-        test-params (assoc train-params "out_of_bag" true)
+(define (optimize-ensemble train-id
+                           validation-id
+                           test-id
+                           objective-id
+                           metric)
+  (let ([trid vid tid] (get-datasets train-id validation-id test-id true)
         obj-id (if (= objective-id "default")
-                   (dataset-get-objective-id dataset-id)
-                   objective-id)
-        otype (or ((fetch dataset-id) ["fields" obj-id "optype"] false)
+                 (dataset-get-objective-id dataset-id)
+                 objective-id)
+        otype (or ((fetch train-id) ["fields" obj-id "optype"] false)
                   (raise {"message" (str "Invalid objective field")}))
-        params (find-optimal-parameters train-params obj-id otype)
+        params (find-optimal-parameters trid tid obj-id otype)
         _ (log-info "SMACdown search complete")
         _ (when delete-resources
             (log-info "Deleting intermediate resources...")
@@ -222,11 +241,10 @@
                         {"objective_field" obj-id
                          "name" "SMACdown Final Model"
                          "seed" "SMACdown"})
-        full-mod (train-general (assoc mod-prms "dataset" dataset-id))
-        train-id (create-dataset train-params)
-        test-id (create-dataset test-params)
-        best-mod (train-general (assoc mod-prms "dataset" train-id))
-        best-eval (create-evaluation best-mod test-id))
+        [trid vid tid] (get-datasets train-id validation-id test-id false)
+        full-mod (train-general (assoc mod-prms "dataset" train-id))
+        best-mod (train-general (assoc mod-prms "dataset" trid))
+        best-eval (create-evaluation best-mod tid))
     (wait* [best-eval full-mod])
     (when delete-resources
       (log-info "Deleting training/evaluation datasets...")
@@ -237,4 +255,5 @@
                  "evaluation" best-eval)
           (tail params))))
 
-(define result (optimize-ensemble dataset-id objective-id metric))
+(define result
+  (optimize-ensemble train-id validation-id test-id objective-id metric))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -107,17 +107,11 @@
         max-nodes 1999
         max-iterations 256
         regression (= "numeric" objective-type)
-        iterations (round (* max-iterations (rand)))
-        early-holdout (rand)
+        iterations (round (rand-range 1 max-iterations))
+        early-holdout (if (< (rand) 0.5) (rand-range 0.1 0.5) 0.0)
         early-out-of-bag (if (< (rand) 0.5) false true)
         step-out-of-bag (if (< (rand) 0.5) false true)
-        learning-rate (rand)
-        learning-rate (if (= learning-rate 1)
-                          (- learning-rate 0.00001)
-                          learning-rate)
-        learning-rate (if (= learning-rate 0)
-                          (+ learning-rate 0.00001)
-                          learning-rate)
+        learning-rate (rand-range 0.00001 0.9)
         cand {"resource_type" "bensemble"
               "stat_pruning" (if (< (rand) 0.5) false true)
               "balance_objective" (if (or regression (< (rand) 0.5))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -199,7 +199,7 @@
               "sample_rate" 0.85
               "replacement" false
               "seed" "SMACdown"}
-        vreq (assoc train-params "out_of_bag" true)
+        vreq (assoc treq "out_of_bag" true)
         [trid vid] (if (empty? validation-id)
                      (let (tset (create-dataset treq)
                            vset (create-dataset vreq)
@@ -227,7 +227,7 @@
                            metric)
   (let ([trid vid tid] (get-datasets train-id validation-id test-id true)
         obj-id (if (= objective-id "default")
-                 (dataset-get-objective-id dataset-id)
+                 (dataset-get-objective-id train-id)
                  objective-id)
         otype (or ((fetch train-id) ["fields" obj-id "optype"] false)
                   (raise {"message" (str "Invalid objective field")}))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -1,8 +1,9 @@
 (define ALL_ATTRS ["resource_type" "stat_pruning" "balance_objective"
                    "randomize" "node_threshold" "random_candidate_ratio"
                    "number_of_models" "bias" "c" "eps" "default_numeric_value"
-                   "missing_numerics" "normalize" "regularization"
-                   "boosting"])
+                   "missing_numerics" "normalize" "regularization" "iterations"
+                   "early_holdout" "early_out_of_bag" "learning_rate"
+                   "step_out_of_bag"])
 
 (define ATTRS_PER_TYPE {"model" ["stat_pruning" "balance_objective"
                                  "randomize" "node_threshold"]
@@ -10,11 +11,18 @@
                                     "balance_objective" "number_of_models"
                                     "randomize" "node_threshold"]
                         "bensemble" ["stat_pruning" "balance_objective"
-                                     "boosting" "randomize" "node_threshold"]
+                                     "randomize" "node_threshold"]
                         "logisticregression" ["bias" "c" "eps"
                                               "default_numeric_value"
                                               "missing_numerics"
                                               "normalize" "regularization"]})
+
+(define BOOSTING_PARAMS ["iterations" "early_holdout" "early_out_of_bag"
+                         "learning_rate" "step_out_of_bag"])
+
+(define (select-boosting-params amap)
+  (let (assoc-param (lambda (m pname) (assoc m pname (amap pname))))
+    (reduce assoc-param {} BOOSTING_PARAMS)))
 
 ;; Here's a custom generator for creating BigML models, ensembles, boosted
 ;; ensembles or logistic regressions
@@ -76,14 +84,10 @@
 (define (smacdown-logistic-regression-params-generator)
   (let (max-c 256
         dnv-random (rand)
-        default-numeric-value (cond (> dnv-random 0.8)
-                                    "mean"
-                                    (> dnv-random 0.6)
-                                    "median"
-                                    (> dnv-random 0.4)
-                                    "minimum"
-                                    (> dnv-random 0.2)
-                                    "maximum"
+        default-numeric-value (cond (> dnv-random 0.8) "mean"
+                                    (> dnv-random 0.6) "median"
+                                    (> dnv-random 0.4) "minimum"
+                                    (> dnv-random 0.2) "maximum"
                                     "zero")
         c (* max-c (rand))
         missing-numerics (if (< (rand) 0.5) false true)
@@ -107,22 +111,17 @@
         max-nodes 1999
         max-iterations 256
         regression (= "numeric" objective-type)
-        iterations (round (rand-range 1 max-iterations))
-        early-holdout (if (< (rand) 0.5) (rand-range 0.1 0.5) 0.0)
-        early-out-of-bag (if (< (rand) 0.5) false true)
-        step-out-of-bag (if (< (rand) 0.5) false true)
-        learning-rate (rand-range 0.00001 0.9)
         cand {"resource_type" "bensemble"
               "stat_pruning" (if (< (rand) 0.5) false true)
               "balance_objective" (if (or regression (< (rand) 0.5))
                                       false
                                       true)
-              "boosting" {"iterations" iterations
-                          "early_holdout" early-holdout
-                          "early_out_of_bag" early-out-of-bag
-                          "learning_rate" learning-rate
-                          "step_out_of_bag" step-out-of-bag}
-              "randomize" true
+              "iterations" (round (rand-range 1 max-iterations))
+              "early_holdout" (if (< (rand) 0.5) (rand-range 0.1 0.5) 0.0)
+              "early_out_of_bag" (if (< (rand) 0.5) false true)
+              "learning_rate" (rand-range 0.00001 0.9)
+              "step_out_of_bag" (if (< (rand) 0.5) false true)
+              "randomize" (if (< (rand) 0.5) false true)
               "node_threshold" (round (rand-range 4 max-nodes))})
     cand))
 
@@ -133,15 +132,14 @@
         params (dissoc params "resource_type")
         attrs (ATTRS_PER_TYPE type []))
     (iterate (p params aa ALL_ATTRS)
-      (if (member? aa attrs)
-          p
-          (dissoc p aa)))))
+      (if (member? aa attrs) p (dissoc p aa)))))
 
 (define (train-general params)
   (let (type (params "resource_type")
         res-params (strict-params params))
     (if (= type "bensemble")
-      (create "ensemble" res-params)
+      (let (bparams (select-boosting-params params))
+        (create "ensemble" (assoc res-params "boosting" bparams)))
       (create type res-params))))
 
 ;; This function takes a training and test set (and an objective field

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -143,6 +143,13 @@
         (create "ensemble" (assoc res-params "boosting" bparams)))
       (create type res-params))))
 
+(define (metric-from-eval metric ev)
+  (let (metric-value (ev ["result" "model" metric] false))
+    (if (not (number? metric-value))
+      (raise {"message" (str metric " is not a valid metric!")
+                            "code" -30})
+      (- 1 metric-value))))
+
 ;; This function takes a training and test set (and an objective field
 ;; id) and evaluates a set of parameters by training a logistic regression with
 ;; those parameters and performing an evaluation on them.  We decide
@@ -160,15 +167,10 @@
           eval-fn (lambda (m) {"model" m "dataset" test})
           mod-params (map mod-fn params)
           mod-ids (map train-general mod-params)
-          eval-ids (create* "evaluation" (map eval-fn mod-ids))
-          phi (lambda (ev)
-                (let (metric-value (ev ["result" "model" metric] false))
-                  (if (not (number? metric-value))
-                    (raise {"message" (str metric " is not a valid metric!")
-                            "code" -30})
-                    (- 1 metric-value)))))
+          eval-ids (create* "evaluation" (map eval-fn mod-ids)))
       (log-info "Evaluation complete.")
-      (map (lambda (eid) (phi (fetch (wait eid)))) eval-ids))))
+      (map (lambda (eid) (metric-from-eval metric (fetch (wait eid))))
+           eval-ids))))
 
 ;; Find optimal parameters using SMACdown
 (define (find-optimal-parameters train-id test-id objective-id objective-type)
@@ -245,11 +247,13 @@
         [trid vid tid] (get-datasets train-id validation-id test-id false)
         full-mod (train-general (assoc mod-prms "dataset" train-id))
         best-mod (train-general (assoc mod-prms "dataset" trid))
-        best-eval (create-evaluation best-mod tid))
+        best-eval (create-evaluation best-mod tid)
+        test-metric (metric-from-eval metric (fetch (wait best-eval))))
     (wait* [best-eval full-mod])
     (cons (assoc (head params)
                  "full_model" full-mod
                  "model" best-mod
+                 (str metric " (test set)") test-metric
                  "evaluation" best-eval)
           (tail params))))
 

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -29,24 +29,18 @@
 ;; models and logistic regressions due to an external issue, but if
 ;; you comment in the uncommented lines and comment out as necessary
 ;; in the cond statement you should be able to re-enable them.
-(define (smacdown-params-generator objective-type)
+(define (params-generator model-types objective-type)
   (lambda ()
-    (let (regression (= "numeric" objective-type)
-          type (rand)
-          ;; type (if (and regression (< type 0.25))
-          ;;         (* 4 type)
-          ;;         type)
-          params (cond (< type 0.25)
-                       ;; (smacdown-logistic-regression-params-generator)
-                       (smacdown-ensemble-params-generator objective-type)
-                       (< type 0.5)
-                       ;; (smacdown-model-params-generator objective-type)
-                       (smacdown-boosted-ensemble-params-generator
-                        objective-type)
-                       (< type 0.75)
-                       (smacdown-ensemble-params-generator objective-type)
-                       (smacdown-boosted-ensemble-params-generator
-                        objective-type)))
+    (let (idx (floor (rand-range 0 (count model-types))))
+          type (model-types idx)
+          params (cond "logisticregression"
+                       (logistic-regression-params-generator)
+                       "ensemble"
+                       (ensemble-params-generator objective-type)
+                       "model"
+                       (model-params-generator objective-type)
+                       "boosted-ensemble"
+                       (boosted-ensemble-params-generator objective-type)))
       (uniformize-params params))))
 
 ;; The smacdown primitive needs a homogeneous set of attributes
@@ -55,7 +49,7 @@
     (if (not (contains? p ap)) (assoc p ap "N/A") p)))
 
 ;; Here's a custom generator for creating BigML models.
-(define (smacdown-model-params-generator objective-type)
+(define (model-params-generator objective-type)
   (let (max-trees 127
         max-nodes 1999
         regression (= "numeric" objective-type)
@@ -71,7 +65,7 @@
 ;; Here's a custom generator for creating BigML ensembles.  As
 ;; "random_candidate_ratio" tends towards 1, the ensemble becomes a
 ;; bag.
-(define (smacdown-ensemble-params-generator objective-type)
+(define (ensemble-params-generator objective-type)
   (let (max-trees 127
         max-nodes 1999
         regression (= "numeric" objective-type)
@@ -85,7 +79,7 @@
     cand))
 
 ;; Here's a custom generator for creating BigML logistic regressions.
-(define (smacdown-logistic-regression-params-generator)
+(define (logistic-regression-params-generator)
   (let (max-c 256
         dnv-random (rand)
         default-numeric-value (cond (> dnv-random 0.8) "mean"
@@ -110,7 +104,7 @@
     cand))
 
 ;; Here's a custom generator for creating BigML boosted ensembles.
-(define (smacdown-boosted-ensemble-params-generator objective-type)
+(define (boosted-ensemble-params-generator objective-type)
   (let (max-trees 127
         max-nodes 1999
         max-iterations 256
@@ -185,13 +179,17 @@
            eval-ids))))
 
 ;; Find optimal parameters using SMACdown
-(define (find-optimal-parameters train-id test-id objective-id objective-type)
+(define (find-optimal-parameters train-id
+                                 test-id
+                                 objective-id
+                                 objective-type
+                                 model-types)
   (let (eval-fn (smacdown-evaluator train-id
                                     test-id
                                     objective-id
                                     metric
                                     "smacdown-model")
-        generator (smacdown-params-generator objective-type)
+        generator (smacdown-params-generator model-types objective-type)
         output (smacdown-optimize generator eval-fn "smacdown-model"))
     (for (p output)
       (assoc (dissoc p smacdown--actual)
@@ -231,6 +229,14 @@
               (prog (when write (log-info "Test set is " test-id)) test-id)))
     (wait* [trid tid vid])))
 
+(define (make-model-types objective-type test-boosting test-model test-logistic)
+  (let (regression (= "numeric" objective-type)
+        test-map {"ensemble" true
+                  "model" test-model
+                  "boosted-ensemble" test-boosting
+                  "logisticregression" (and test-logistic (not regression))})
+    (reduce (lambda (v k) (if (test-map k) (cons k v) v)) [] (keys test-map))))
+
 ;; Take a dataset, create a training and test set, and find the
 ;; optimal parameters.  The function returns a list of parameters
 ;; ranked by objective.
@@ -238,14 +244,18 @@
                            validation-id
                            test-id
                            objective-id
-                           metric)
+                           metric
+                           test-boosting
+                           test-model
+                           test-logistic)
   (let ([trid vid tid] (get-datasets train-id validation-id test-id true)
         obj-id (if (= objective-id "default")
                  (dataset-get-objective-id train-id)
                  objective-id)
         otype (or ((fetch train-id) ["fields" obj-id "optype"] false)
                   (raise {"message" (str "Invalid objective field")}))
-        params (find-optimal-parameters trid tid obj-id otype)
+        mtypes (make-model-types otype test-boosting test-model test-logistic)
+        params (find-optimal-parameters trid tid obj-id otype mtypes)
         _ (log-info "SMACdown search complete")
         _ (when delete-resources
             (log-info "Deleting intermediate resources...")
@@ -270,4 +280,11 @@
           (tail params))))
 
 (define result
-  (optimize-ensemble train-id validation-id test-id objective-id metric))
+  (optimize-ensemble train-id
+                     validation-id
+                     test-id
+                     objective-id
+                     metric
+                     test-boosting
+                     test-model
+                     test-logistic))

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -146,8 +146,17 @@
         (create "ensemble" (assoc res-params "boosting" bparams)))
       (create type res-params))))
 
+(define (stats-for-class class per-class-stats)
+  (some (lambda (c) (when (= class (c "class_name")) c)) per-class-stats))
+
 (define (metric-from-eval metric ev)
-  (let (metric-value (ev ["result" "model" metric] false))
+  (let (met-matches (matches "(.*)->(.*)" metric)
+        metric-value (if (empty? met-matches)
+                       (ev ["result" "model" metric] false)
+                       (let ([class class-met] (tail met-matches)
+                             pcs (ev ["result" "model" "per_class_statistics"])
+                             cstats (stats-for-class pcs))
+                         (cstats class-met))))
     (if (not (number? metric-value))
       (raise {"message" (str metric " is not a valid metric!")
               "code" -30})

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -203,7 +203,7 @@
           type (params "resource_type")
           res-params (dissoc (params-for-resource params) "resource_type"))
       (assoc {"parameters" res-params "resource_type" type}
-             (str metric) (- 1 (p smacdown--actual)))))))
+             (str metric) (- 1 (p smacdown--actual))))))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -247,9 +247,6 @@
         best-mod (train-general (assoc mod-prms "dataset" trid))
         best-eval (create-evaluation best-mod tid))
     (wait* [best-eval full-mod])
-    (when delete-resources
-      (log-info "Deleting training/evaluation datasets...")
-      (map safe-delete [train-id test-id]))
     (cons (assoc (head params)
                  "full_model" full-mod
                  "model" best-mod

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -31,7 +31,7 @@
 ;; in the cond statement you should be able to re-enable them.
 (define (params-generator model-types objective-type)
   (lambda ()
-    (let (idx (floor (rand-range 0 (count model-types))))
+    (let (idx (floor (rand-range 0 (count model-types)))
           type (model-types idx)
           params (cond "logisticregression"
                        (logistic-regression-params-generator)

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -33,13 +33,13 @@
   (lambda ()
     (let (idx (floor (rand-range 0 (count model-types)))
           type (model-types idx)
-          params (cond "logisticregression"
+          params (cond (= type "logisticregression")
                        (logistic-regression-params-generator)
-                       "ensemble"
+                       (= type "ensemble")
                        (ensemble-params-generator objective-type)
-                       "model"
+                       (= type "model")
                        (model-params-generator objective-type)
-                       "boosted-ensemble"
+                       (= type "boosted-ensemble")
                        (boosted-ensemble-params-generator objective-type)))
       (uniformize-params params))))
 

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -134,7 +134,7 @@
     (iterate (p params aa ALL_ATTRS)
       (if (member? aa attrs) p (dissoc p aa)))))
 
-(define (train-general params dataset-id)
+(define (train-general params)
   (let (type (params "resource_type")
         res-params (strict-params params))
     (if (= type "bensemble")

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -148,7 +148,7 @@
         res-params (strict-params params))
     (if (= type "bensemble")
       (create "ensemble" res-params)
-      (create "type" res-params))))
+      (create type res-params))))
 
 ;; This function takes a training and test set (and an objective field
 ;; id) and evaluates a set of parameters by training a logistic regression with

--- a/smacdown-ensemble/script.whizzml
+++ b/smacdown-ensemble/script.whizzml
@@ -194,15 +194,16 @@
                                     objective-id
                                     metric
                                     "smacdown-model")
-        generator (params-generator model-types objective-type)
-        output (smacdown-optimize generator eval-fn "smacdown-model"))
-    (for (p output)
-      (let (params (p "parameters")
-            type (params "resource_type")
-            mkey (str metric)
-            res-params (dissoc (params-for-resource params) "resource_type"))
-        (assoc {"parameters" res-params "resource_type" type}
-               mkey (- 1 (p smacdown--actual)))))))
+        generator (params-generator model-types objective-type))
+    (smacdown-optimize generator eval-fn "smacdown-model")))
+
+(define (format-output output)
+  (for (p output)
+    (let (params (p "parameters")
+          type (params "resource_type")
+          res-params (dissoc (params-for-resource params) "resource_type"))
+      (assoc {"parameters" res-params "resource_type" type}
+             (str metric) (- 1 (p smacdown--actual)))))))
 
 ;; Delete resources ignoring errors
 (define (safe-delete id)
@@ -275,6 +276,7 @@
                                  test-logistic)
         _ (log-info "Search over types: " (str mtypes))
         params (find-optimal-parameters trid tid obj-id otype mtypes)
+        output-params (format-output params)
         _ (log-info "SMACdown search complete")
         _ (when delete-resources
             (log-info "Deleting intermediate resources...")
@@ -291,12 +293,12 @@
         best-eval (create-evaluation best-mod tid)
         test-metric (metric-from-eval metric (fetch (wait best-eval))))
     (wait* [best-eval full-mod])
-    (cons (assoc (head params)
+    (cons (assoc (head output-params)
                  "full_model" full-mod
                  "model" best-mod
                  (str metric " (test set)") test-metric
                  "evaluation" best-eval)
-          (tail params))))
+          (tail output-params))))
 
 (define result
   (optimize-ensemble train-id


### PR DESCRIPTION
Here's a first iteration of SMAC that generalizes to operate over most supervised resource types.  This also adds the ability to specify a specific validation / test set requested long ago by @talverez.  

Really, we're going to need two separate SMAC scripts now - one that takes the specific sets as arguments and one that doesn't, given that we can't have optional dataset arguments.

Also, you see from the changes here:

https://github.com/mmerce/examples/pull/1/files#diff-c4aafe65c844ac8f2575ee103a88d66cL21

That i've disabled logistic regression and one-tree models for now.  It works if you enable these, but the algorithm exhibits a preference for logistic regression models, which should be resolved by  https://github.com/bigmlcom/whizzml/pull/132, which is not yet in prod.  Once it is, we can re-enable those types and split this script into two.